### PR TITLE
Since py 2.6 doesn't support dict comprehension, I've switched to compat...

### DIFF
--- a/blivet/platform.py
+++ b/blivet/platform.py
@@ -113,7 +113,7 @@ class Platform(object):
              "raid_levels": self._boot_stage1_raid_levels,
              "raid_metadata": self._boot_stage1_raid_metadata,
              "raid_member_types": self._boot_stage1_raid_member_types,
-             "descriptions": {k: _(v) for k, v in self._boot_descriptions.items()}}
+             "descriptions": dict((k, _(v)) for k, v in self._boot_descriptions.items())}
         return d
 
     def requiredDiskLabelType(self, device_type):


### PR DESCRIPTION
Since py 2.6 doesn't support dict comprehension, I've switched to compatible syntax here.

If the deps can be met, this allows blivet to run on EL6 which is somethign I've active interest in.

Someone should double check the test suite, it worked for me but.....