### PR TITLE
Add initial support for MIPS architecture

### DIFF
--- a/blivet/arch.py
+++ b/blivet/arch.py
@@ -293,6 +293,21 @@ def isPPC(bits=None):
 
     return False
 
+def isMIPS(bits=None):
+    arch = os.uname()[4]
+
+    if bits is None:
+        if arch.startswith('mips'):
+            return True
+    elif bits == 32:
+        if arch == 'mips':
+            return True
+    elif bits == 64:
+        if arch == 'mips64':
+            return True
+
+    return False
+
 def isS390():
     """
     :return: True if the hardware supports PPC, False otherwise.
@@ -340,6 +355,10 @@ def getArch():
     elif isPPC(bits=64):
         # ppc64 and ppc64le are distinct architectures
         return os.uname()[4]
+    elif isMIPS(bits=32):
+        return 'mips'
+    elif isMIPS(bits=64):
+        return 'mips64'
     elif isAARCH64():
         return 'aarch64'
     elif isAlpha():

--- a/blivet/platform.py
+++ b/blivet/platform.py
@@ -421,6 +421,18 @@ class omapARM(ARM):
         else:
             return Platform.weight(self, fstype=fstype, mountpoint=mountpoint)
 
+class MIPS(Platform):
+    _mipsMachine = None
+    _boot_stage1_device_types = ["disk"]
+    _boot_mbr_description = N_("Master Boot Record")
+    _boot_descriptions = {"disk": _boot_mbr_description,
+                          "partition": Platform._boot_partition_description}
+
+    _disklabel_types = ["msdos"]
+    _boot_stage1_missing_error = N_("You must include at least one MBR-formatted "
+                                    "disk as an install target.")
+
+
 def getPlatform():
     """Check the architecture of the system and return an instance of a
        Platform subclass to match.  If the architecture could not be determined,
@@ -453,6 +465,8 @@ def getPlatform():
             return omapARM()
         else:
             return ARM()
+    elif arch.isMIPS():
+        return MIPS()
     else:
         raise SystemError("Could not determine system architecture.")
 


### PR DESCRIPTION
Introduce minimal MIPS objects, just enough to prevent initial-setup from dying
